### PR TITLE
Replace deprecated SortedDict with python builtin OrderedDict

### DIFF
--- a/hashers_passlib/__init__.py
+++ b/hashers_passlib/__init__.py
@@ -18,9 +18,10 @@
 
 from __future__ import unicode_literals
 
+from collections import OrderedDict
+
 from django.contrib.auth.hashers import BasePasswordHasher
 from django.contrib.auth.hashers import mask_hash
-from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext_noop as _
 
 _SETTINGS_MAPPING = (
@@ -96,7 +97,7 @@ class PasslibHasher(BasePasswordHasher):
         for key, value in parsed.items():
             data.append((_(key), value))
 
-        return SortedDict(data + to_append)
+        return OrderedDict(data + to_append)
 
 
 class PasslibCryptSchemeHasher(PasslibHasher):


### PR DESCRIPTION
SortedDict was removed in django 1.9.
OrderedDict is available in python 2.7 and 3.1+, i.e. all supported python versions.

I could'n test this change due to https://github.com/mathiasertl/django-hashers-passlib/issues/3.
