### PR TITLE
Remove deprecated ugettext import

### DIFF
--- a/hashers_passlib/__init__.py
+++ b/hashers_passlib/__init__.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from django.conf import settings
 from django.contrib.auth.hashers import BasePasswordHasher
 from django.contrib.auth.hashers import mask_hash
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import gettext_noop as _
 
 _SETTINGS_MAPPING = (
     (_('rounds'), 'iterations', False),


### PR DESCRIPTION
This fixes compatibility for Django 4.0.